### PR TITLE
retorna à migração 0011

### DIFF
--- a/web/admin.py
+++ b/web/admin.py
@@ -60,6 +60,6 @@ class ServiceAdmin(admin.ModelAdmin):
 
 @admin.register(Proposal)
 class ProposalAdmin(admin.ModelAdmin):
-    list_display = ("objective",)
+    list_display = ("id", "client","objective","collection_date")
     list_display_links = ("objective",)
     search_fields = ("objective",)

--- a/web/forms.py
+++ b/web/forms.py
@@ -75,4 +75,6 @@ class ProposalForm(forms.ModelForm):
             "id",
             "client",
             "objective",
+            "collection_date",
+            "legal_basis"
        ]

--- a/web/models.py
+++ b/web/models.py
@@ -112,6 +112,7 @@ class Client(Company):
         return self.corporate_name
 
 class Event(models.Model):
+    # o Django tem um tipo próprio pra fazer Enum
     priorities_list = (
         ('0', 'Sem prioridade'),
         ('1', 'Normal'),


### PR DESCRIPTION
Restaura o estado do banco de dados para a migração 0011:

 ```
./manage.py showmigrations
admin
 [X] 0001_initial
 [X] 0002_logentry_remove_auto_add
 [X] 0003_logentry_add_action_flag_choices
auth
 [X] 0001_initial
 [X] 0002_alter_permission_name_max_length
 [X] 0003_alter_user_email_max_length
 [X] 0004_alter_user_username_opts
 [X] 0005_alter_user_last_login_null
 [X] 0006_require_contenttypes_0002
 [X] 0007_alter_validators_add_error_messages
 [X] 0008_alter_user_username_max_length
 [X] 0009_alter_user_last_name_max_length
 [X] 0010_alter_group_name_max_length
 [X] 0011_update_proxy_permissions
 [X] 0012_alter_user_first_name_max_length
contenttypes
 [X] 0001_initial
 [X] 0002_remove_content_type_name
members
 (no migrations)
sessions
 [X] 0001_initial
web
 [X] 0001_initial
 [X] 0002_contractingcompany_otherdocuments_contractedcompany
 [X] 0003_environmentalconsultancy_and_more
 [X] 0004_matrix
 [X] 0005_sample
 [X] 0006_parameter_rename_otherdocuments_documents_and_more
 [X] 0007_rename_documents_document_and_more
 [X] 0008_product
 [X] 0009_service
 [X] 0010_proposal_client_nickname_and_more
 [X] 0011_proposal_client
```
